### PR TITLE
make selection of seed ids to fetch from servers more flexible

### DIFF
--- a/obspyck/example.cfg
+++ b/obspyck/example.cfg
@@ -1,7 +1,4 @@
 [base]
-# station_combination: str
-# must be defined in section <station_combinations>
-station_combination = EXAMPLE1
 # duration: int or float
 duration = 3600
 # starttime_offset: int or float


### PR DESCRIPTION
 - multiple station combinations can be specified on command line now.
   so, station combinations in the config file can be made up more
   logically structured
 - reintroduce the possibility to specify a specific seed id to fetch on
   command line (option '-i'/'--id', can be specified multiple times)