### PR TITLE
make it possible to use custom phases besides 'P' and 'S'

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,11 @@ master
    for longitude <0 (see #47)
  - fix horizontal errors read after hyp2000 location (conversion from km to m
    was missing, see #48)
+ - add possibility to use other phase names besides the default "P" and "S" in
+   picking. this is highly experimental, especially when using location
+   routines most internals are very likely still using hard coded "P" and "S"
+   values, but for picking and saving to QuakeML only this reportedly works
+   (see #36).
 
 0.4.1
  - fix minor bug that prevents 0.4.0 from running

--- a/obspyck/example.cfg
+++ b/obspyck/example.cfg
@@ -39,6 +39,16 @@ scrollWheelPercentage = 0.30
 # whether to revert scroll direction
 scrollWheelInvert = false
 
+[seismic_phases]
+# keys: phase hint (case sensitive)
+# values: color specification understood by matplotlib.colors.ColorConverter.to_rgb()
+#         (matplotlib color names, hex color strings, ...)
+# please note that some parts might (especially interactions with location routines etc.)
+# very likely use hard coded 'P' and 'S' phases so check if you're getting the
+# expected results when using other phase names! Modify at your own risk!
+P = red
+S = blue
+
 [station_combinations]
 EXAMPLE1 = II.PFO.00.LH?,GE.APE..LH?,GE.PSZ..LH?,CI.BBR..LH*,IV.PRMA..LH?,G.RER..LH*
 EXAMPLE2 = 7A.W01..LH?,CI.BBR..LH*

--- a/obspyck/util.py
+++ b/obspyck/util.py
@@ -118,8 +118,6 @@ PROGRAMS = {
         'focmec': {'filenames': {'exe': "rfocmec", 'phases': "focmec.dat",
                                  'stdout': "focmec.stdout",
                                  'summary': "focmec.out"}}}
-SEISMIC_PHASES = ('P', 'S')
-PHASE_COLORS = {'P': "red", 'S': "blue", 'Mag': "green"}
 COMPONENT_COLORS = {'Z': "k", 'N': "b", 'E': "r"}
 WIDGET_NAMES = ("qToolButton_clearAll", "qToolButton_clearOrigMag",
         "qToolButton_clearFocMec", "qToolButton_doHyp2000",


### PR DESCRIPTION
picking and saving to quakeml works, but interactions with location
routines etc. will probably very likely still only use pure 'P' and
'S' for now..