### PR TITLE
Panning / scrolling along the time axis

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@ master
  - add support for magnitude estimation for data fetched from an FDSN server
    (using full response)
  - depending on obspy >=1.1.0 now
+ - add support for scrolling along time axis with mouse wheel + modifier
+   (by default "alt" key, see #45)
 
 0.4.1
  - fix minor bug that prevents 0.4.0 from running

--- a/obspyck/example.cfg
+++ b/obspyck/example.cfg
@@ -34,6 +34,10 @@ magnitude_picker_width = 10
 # experimental, not sure what happens when modifying/deleting/saving to
 # QuakeML, use at your own risk!
 allow_multiple_picks_with_same_seed_id = false
+# percentage to scroll with wheel, deciaml from 0.0 to 1.0
+scrollWheelPercentage = 0.30
+# whether to revert scroll direction
+scrollWheelInvert = false
 
 [station_combinations]
 EXAMPLE1 = II.PFO.00.LH?,GE.APE..LH?,GE.PSZ..LH?,CI.BBR..LH*,IV.PRMA..LH?,G.RER..LH*
@@ -93,6 +97,7 @@ nextStream = x
 # mouse wheels zooms time axis by default, but when this key is held down it
 # zooms amplitude axis instead
 switchWheelZoomAxis = shift
+scrollWheelZoom = alt
 setWeight0 = 0
 setWeight1 = 1
 setWeight2 = 2

--- a/obspyck/obspyck.py
+++ b/obspyck/obspyck.py
@@ -1593,7 +1593,7 @@ class ObsPyck(QtGui.QMainWindow):
         # End of key events related to picking                                #
         #######################################################################
 
-        if ev.key == keys['switchWheelZoomAxis']:
+        if ev.key in (keys['switchWheelZoomAxis'], keys['scrollWheelZoom']):
             return
 
         # iterate the phase type combobox
@@ -1667,6 +1667,25 @@ class ObsPyck(QtGui.QMainWindow):
                 elif ev.delta() > 0:
                     top /= 2
                     bottom /= 2
+        # Still able to use the dictionary.
+        elif ev.modifiers() == getattr(
+                QtCore.Qt,
+                '%sModifier' % self.keys['scrollWheelZoom'].capitalize()):
+            direction = (self.config.getboolean('misc', 'scrollWheelInvert')
+                         and 1 or -1)
+            shift = ((right - left) *
+                     self.config.getfloat('misc', 'scrollWheelPercentage'))
+            if self.widgets.qToolButton_showMap.isChecked():
+                pass
+            else:
+                # scroll left
+                if ev.delta() * direction < 0:
+                    left -= shift
+                    right -= shift
+                # scroll right
+                elif ev.delta() * direction > 0:
+                    left += shift
+                    right += shift
         ax.set_xbound(lower=left, upper=right)
         ax.set_ybound(lower=bottom, upper=top)
         self.redraw()

--- a/obspyck/obspyck.py
+++ b/obspyck/obspyck.py
@@ -201,9 +201,6 @@ class ObsPyck(QtGui.QMainWindow):
         facecolor = self.qMain.palette().color(QtGui.QPalette.Window).getRgb()
         self.fig.set_facecolor([value / 255.0 for value in facecolor])
 
-        #Define some flags, dictionaries and plotting options
-        #this next flag indicates if we zoom on time or amplitude axis
-        self.flagWheelZoomAmplitude = False
         try:
             self.tmp_dir = setup_external_programs(options, config)
         except IOError:
@@ -301,7 +298,6 @@ class ObsPyck(QtGui.QMainWindow):
         # XXX MAYBE rename the event handles again so that they DONT get
         # XXX autoconnected via Qt?!?!?
         self.canv.mpl_connect('key_press_event', self.__mpl_keyPressEvent)
-        self.canv.mpl_connect('key_release_event', self.__mpl_keyReleaseEvent)
         self.canv.mpl_connect('button_release_event', self.__mpl_mouseButtonReleaseEvent)
         # The scroll event is handled using Qt.
         #self.canv.mpl_connect('scroll_event', self.__mpl_wheelEvent)
@@ -1598,7 +1594,6 @@ class ObsPyck(QtGui.QMainWindow):
         #######################################################################
 
         if ev.key == keys['switchWheelZoomAxis']:
-            self.flagWheelZoomAmplitude = True
             return
 
         # iterate the phase type combobox
@@ -1620,10 +1615,6 @@ class ObsPyck(QtGui.QMainWindow):
                 return
             self.on_qToolButton_nextStream_clicked()
             return
-
-    def __mpl_keyReleaseEvent(self, ev):
-        if ev.key == self.keys['switchWheelZoomAxis']:
-            self.flagWheelZoomAmplitude = False
 
     # Define zooming for the mouse wheel wheel
     def __mpl_wheelEvent(self, ev):


### PR DESCRIPTION
Tobias,

I realise it's possible to scroll and zoom in/out along the time axis using Shift + mouse-wheel. However, I haven't yet found a command to scroll/pan only (without any zoom). 

Is this possible?

Thanks,
S