### PR TITLE
plot picks that don't have the location code specified (in the QuakeML file)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,10 @@ master
    routines most internals are very likely still using hard coded "P" and "S"
    values, but for picking and saving to QuakeML only this reportedly works
    (see #36).
+ - also show picks in the GUI that lack location code in the corresponding
+   QuakeML file (but such picks will not be associated to any one of the
+   Stream's axes, so it will not be possible to modify or delete them via the
+   GUI, see #49 and #51)
 
 0.4.1
  - fix minor bug that prevents 0.4.0 from running

--- a/obspyck/obspyck.py
+++ b/obspyck/obspyck.py
@@ -3024,7 +3024,7 @@ class ObsPyck(QtGui.QMainWindow):
             # match any location code in that case..
             if str(event.get("creation_info", {}).get("author", "")).startswith("scevent"):
                 loc = None
-            picks = self.getPicks(network=net, station=sta, location=loc)
+            picks = self.getPicks(network=net, station=sta)
             try:
                 arrivals = event.origins[0].arrivals
             except:
@@ -3815,7 +3815,7 @@ class ObsPyck(QtGui.QMainWindow):
         # match any location code in that case..
         if event.get("creation_info", {}).get("author", "").startswith("scevent"):
             loc = None
-        picks = self.getPicks(network=net, station=sta, location=loc)
+        picks = self.getPicks(network=net, station=sta)
         try:
             arrivals = event.origins[0].arrivals
         except:
@@ -4002,7 +4002,7 @@ class ObsPyck(QtGui.QMainWindow):
         else:
             return None
 
-    def getPicks(self, network, station, location):
+    def getPicks(self, network, station, location=None):
         """
         returns all matching picks as list.
         """
@@ -4013,8 +4013,9 @@ class ObsPyck(QtGui.QMainWindow):
                 continue
             if station != p.waveform_id.station_code:
                 continue
-            if location != p.waveform_id.location_code:
-                continue
+            if location is not None:
+                if location != p.waveform_id.location_code:
+                    continue
             ret.append(p)
         return ret
 


### PR DESCRIPTION
These will plot as "foreign channel" picks in the normal Stream plot, i.e. they will not be associated to
any axes, as the axes/Traces/waveforms will always have a location code set. This implies that these picks won't ever be modifiable/deletable through the GUI..

Only solution I an think of right now to make them really accessible in the GUI would be to add an option to specify default location and channel codes for network/station combinations in the config file..

Fixes #49.