### PR TITLE
Show picks for all events in QuakeML between given starttime & endtime

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,9 @@ master
  - add possibility to specify complex, time-dependent station combinations
    (see #73)
  - avoid errors when encountering arrivals without a residual time (see #52)
+ - add experimental option for reviewing all picks in a given catalog (as
+   opposed to normal operation which only considers the first event in a loaded
+   catalog file, see #50)
 
 0.5.1
  - fix getting metadata via arclink (see #65)

--- a/obspyck/event_helper.py
+++ b/obspyck/event_helper.py
@@ -307,3 +307,23 @@ def readQuakeML(*args, **kwargs):
     for classname, class_ in bkp.iteritems():
         obspy.io.quakeml.core.__dict__[classname] = bkp[classname]
     return ret
+
+
+def merge_events_in_catalog(catalog):
+    """
+    Merge information contained in all events (origins, picks, magnitudes, ...)
+    in the catalog into the first event in the catalog.
+    WARNING: Works in place!
+    """
+    if len(catalog) < 2:
+        return
+    event = Event()
+    for e in catalog:
+        event.picks += e.picks
+        event.origins += e.origins
+        event.magnitudes += e.magnitudes
+        event.amplitudes += e.amplitudes
+        event.focal_mechanisms += e.focal_mechanisms
+        event.station_magnitudes += e.station_magnitudes
+        event.comments += e.comments
+    catalog.events = [e]

--- a/obspyck/example.cfg
+++ b/obspyck/example.cfg
@@ -43,6 +43,12 @@ allow_multiple_picks_with_same_seed_id = false
 scrollWheelPercentage = 0.30
 # whether to revert scroll direction
 scrollWheelInvert = false
+# whether to merge Catalog upon reading/fetching. In normal operation obspyck
+# only considers the first event in a Catalog read from QuakeML or fetched from
+# a server. Using this switch obspyck instead merges information of all events
+# into one single event. Highly experimental. Should not be used for anything
+# else than review of existing events. USE AT YOUR OWN RISK.
+merge_events_in_catalog = false
 
 [seismic_phases]
 # keys: phase hint (case sensitive)

--- a/obspyck/obspyck.py
+++ b/obspyck/obspyck.py
@@ -57,7 +57,8 @@ from .qt_designer import Ui_qMainWindow_obsPyck
 from .util import *
 from .event_helper import Catalog, Event, Origin, Pick, Arrival, \
     Magnitude, StationMagnitude, StationMagnitudeContribution, \
-    FocalMechanism, ResourceIdentifier, ID_ROOT, readQuakeML, Amplitude
+    FocalMechanism, ResourceIdentifier, ID_ROOT, readQuakeML, Amplitude, \
+    merge_events_in_catalog
 
 NAMESPACE = "http://erdbeben-in-bayern.de/xmlns/0.1"
 NSMAP = {"edb": NAMESPACE}
@@ -4426,6 +4427,19 @@ class ObsPyck(QtGui.QMainWindow):
         Set the currently active Event/Catalog.
         """
         self.catalog = catalog
+
+        try:
+            merge_events_in_catalog = self.config.getboolean(
+                'misc', 'merge_catalog')
+        except NoOptionError:
+            merge_events_in_catalog = False
+        if merge_events_in_catalog:
+            msg = ('Warning: Option to merge events in the catalog is highly '
+                   'experimental and should only be used for reviewing '
+                   'existing events.')
+            self.error(msg)
+            merge_events_in_catalog(self.catalog)
+
         string_io = StringIO()
         catalog.write(string_io, format="QUAKEML")
         string_io.seek(0)


### PR DESCRIPTION
Hi,

Currently it is possible to plot the picks for one single event (the first one) of the quakeml file. Shall we consider the idea of plotting all the picks associated to multiple events (if t0 of all events are between starttime and endtime given in command line)? Is that out of scope of obspyck's philosophy?

Thanks,

Christian

