### PR TITLE
fix getting coordinates/PAZ from arclink

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 master
+ - fix getting metadata via arclink (see #65)
 
 0.5.0
  - add support for magnitude estimation for data fetched from an FDSN server

--- a/obspyck/util.py
+++ b/obspyck/util.py
@@ -467,8 +467,8 @@ def fetch_waveforms_with_metadata(options, args, config):
                         tr.stats.orientation = \
                             get_orientation_from_parser(p_, tr.id, datetime=t1)
                         tr.stats.coordinates = \
-                            p_.getCoordinates(tr.id, datetime=t1)
-                        tr.stats.paz = p_.getPAZ(tr.id, datetime=t1)
+                            p_.get_coordinates(tr.id, datetime=t1)
+                        tr.stats.paz = p_.get_paz(tr.id, datetime=t1)
             # FDSN (or JANE)
             elif server_type in ("fdsn", "jane"):
                 st = client.get_waveforms(


### PR DESCRIPTION
was still old obspy syntax that doesnt work on obspy 1.1.*