### PR TITLE
reimplement AR picker

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ master
    acceleration (so far always was converting to velocity; see #43)
  - use obspy read_inventory() and Inventory/Response objects internally for
    all metadata, regardless of source (see #77)
+ - reimplement AR picker (see #75)
 
 0.5.1
  - fix getting metadata via arclink (see #65)

--- a/obspyck/example.cfg
+++ b/obspyck/example.cfg
@@ -237,3 +237,17 @@ default_pick_uncertainty = 0.05
 [matplotlibrc]
 lines.linewidth = 1.0
 font.size = 10
+
+[ar_picker]
+# for meaning of parameters, see obspy documentation for routine
+# obspy.signal.trigger.ar_pick
+f1 = 1.0
+f2 = 20.0
+lta_p = 1.0
+sta_p = 0.1
+lta_s = 4.0
+sta_s = 1.0
+m_p = 2
+m_s = 8
+l_p = 0.1
+l_s = 0.2


### PR DESCRIPTION
This PR adds support for obspy's AR picker again, which was dropped during the transition to the new canonical internal structure for handling event information.

CC @jwassermann

Currently only works with hardcoded AR picker parameters from obspyck config file (default location `~/.obspyckrc`), so parameters can not be tuned interactively in the GUI..