### PR TITLE
make time axis origin be at given reference time always

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,9 @@ master
  - use obspy read_inventory() and Inventory/Response objects internally for
    all metadata, regardless of source (see #77)
  - reimplement AR picker (see #75)
+ - make reference time given on command line the zero-time on time axis always
+   (so far if an offset was given the zero time was equal to reference time
+   plus offset, see #78)
 
 0.5.1
  - fix getting metadata via arclink (see #65)

--- a/obspyck/util.py
+++ b/obspyck/util.py
@@ -762,7 +762,7 @@ def merge_check_and_cleanup_streams(streams, options, config):
         if len(st) != len(st.select(network=st[0].stats.network,
                                     station=st[0].stats.station)):
             msg = "Warning: Stream with a mix of stations/networks. " + \
-                  "Discarding stream."
+                  "Discarding stream:\n%s" % str(st)
             print msg
             warn_msg += msg + "\n"
             streams.remove(st)

--- a/obspyck/util.py
+++ b/obspyck/util.py
@@ -1053,12 +1053,21 @@ def formatXTicklabels(x, *pos):
     # x is of type numpy.float64, the string representation of that float
     # strips of all tailing zeros
     # pos returns the position of x on the axis while zooming, None otherwise
-    min = int(x / 60.)
-    if min > 0:
-        sec = x % 60
-        return "%i:%06.3f" % (min, sec)
-    else:
-        return "%.3f" % x
+    info = []
+
+    if x < 0:
+        info.append('-')
+    x = abs(x)
+
+    minutes = int(x / 60.)
+    seconds = x % 60
+
+    if minutes > 0:
+        info.append('%imin' % minutes)
+
+    info.append("%ss" % seconds)
+
+    return ' '.join(info)
 
 
 def coords2azbazinc(stream, origin):


### PR DESCRIPTION
I.e. in the plot 0.0s (origin of time/x-axis) is actually the time given on command line with option `-t`. Before, if an offset was given on command line, the 0-time in the plot was reference time shifted by offset.
This helps e.g. to easily read travel times if an origin time was given as reference time on command line.