### PR TITLE
fix adjusting spectrogram extent when no starttime offset was specified

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 master
- - ...
+ - fix changing extent of spectrogram image if no starttime offset is specified
+   in either config file (as default) or on command line (see #89)
 
 0.6.0
  - avoid error when special use case key `test_event_server_jane` is not

--- a/obspyck/obspyck.py
+++ b/obspyck/obspyck.py
@@ -1463,14 +1463,15 @@ class ObsPyck(QtGui.QMainWindow):
                             cmap=self.spectrogramColormap, axes=ax, zorder=-10)
                 textcolor = "red"
                 # adjust spectrogram start time offset, relative to reference time
-                if log:
-                    quadmesh_ = ax.collections[0]
-                    quadmesh_._coordinates[:, :, 0] += self.options.starttime_offset
-                else:
-                    x1, x2, y1, y2 = ax.images[0].get_extent()
-                    ax.images[0].set_extent((
-                        x1 + self.options.starttime_offset,
-                        x2 + self.options.starttime_offset, y1, y2))
+                if self.options.starttime_offset:
+                    if log:
+                        quadmesh_ = ax.collections[0]
+                        quadmesh_._coordinates[:, :, 0] += self.options.starttime_offset
+                    else:
+                        x1, x2, y1, y2 = ax.images[0].get_extent()
+                        ax.images[0].set_extent((
+                            x1 + self.options.starttime_offset,
+                            x2 + self.options.starttime_offset, y1, y2))
             else:
                 # normalize with overall sensitivity and convert to nm/s
                 # if not explicitly deactivated on command line


### PR DESCRIPTION
If no starttime offset was used (in either config file as default or on command line), there was an error adding `None` and `float`.

Need to double check before merging.