### PR TITLE
fix imports for quakeml reading after Python 3 port

### DIFF
--- a/obspyck/event_helper.py
+++ b/obspyck/event_helper.py
@@ -4,6 +4,9 @@ import warnings
 from copy import deepcopy
 
 import obspy.core.event
+import obspy.io
+import obspy.io.quakeml
+import obspy.io.quakeml.core
 from obspy import UTCDateTime
 from obspy.core.event import WaveformStreamID, ResourceIdentifier, \
     TimeWindow, CreationInfo, Comment


### PR DESCRIPTION
Somehow these imports worked before but not after Py3 port anymore, so import these submodules explicitely.