### PR TITLE
Modernize rotate to ZNE

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ master:
  - remove streams that make problems due to masked values and show a warning
  - make scrollWheelPercentage from config affect all scroll events
  - fix mouse wheel scrolling with Alt key held down
+ - cleanup and modernize rotation to ZNE (see #101)
 
 0.8.1
  - fix reading QuakeML after Python3 port (see #98)

--- a/obspyck/obspyck.py
+++ b/obspyck/obspyck.py
@@ -94,6 +94,9 @@ class ObsPyck(QtWidgets.QMainWindow):
         self.streams = streams
         self.keys = keys
         self.config = config
+        self.inventory = inventories[0]
+        for inv in inventories[1:]:
+            self.inventory += inv
 
         # make a mapping of seismic phases to colors as specified in config
         self.seismic_phases = OrderedDict(config.items('seismic_phases'))


### PR DESCRIPTION
- don't do rotation from original input data to ZNE during startup anymore(which comes before optional instrument), but rather do it on the fly whenswitching between streams and do it after optional instrument correction, sothat instrument correction works properly and doesn't have to rely on metadata attached to traces which might not be valid anymore if all three channels do not share the same response 
- get rid of some custom rotation code (that made it's way into obspy  years ago) and rather just use the obspy high level rotate command  and the complete Inventory for all data 
