### PR TITLE
remove MultiCursor __init__ overwrite

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,8 @@ master:
  - fix mouse wheel scrolling with Alt key held down
  - cleanup and modernize rotation to ZNE (see #101)
  - improve setting amplitude picks when loading existing events (see #102)
+ - remove MultiCursor patch that seems to not be needed anymore and breaks in
+   matplotlib>=3.6 (see #103)
 
 0.8.1
  - fix reading QuakeML after Python3 port (see #98)

--- a/obspyck/util.py
+++ b/obspyck/util.py
@@ -867,29 +867,7 @@ def setup_external_programs(options, config):
     #######################################################################
     return tmp_dir
 
-#Monkey patch (need to remember the ids of the mpl_connect-statements to remove them later)
-#See source: http://matplotlib.sourcearchive.com/documentation/0.98.1/widgets_8py-source.html
 class MultiCursor(MplMultiCursor):
-    def __init__(self, canvas, axes, useblit=True, **lineprops):
-        if hasattr(self, "id1"):
-            self.canvas.mpl_disconnect(self.id1)
-            self.canvas.mpl_disconnect(self.id2)
-        self.canvas = canvas
-        self.axes = axes
-        xmin, xmax = axes[-1].get_xlim()
-        xmid = 0.5*(xmin+xmax)
-        self.hlines = []
-        self.vlines = []
-        self.horizOn = False
-        self.vertOn = True
-        self.lines = [ax.axvline(xmid, visible=False, **lineprops) for ax in axes]
-        self.visible = True
-        self.useblit = useblit
-        self.background = None
-        self.needclear = False
-        self.id1 = self.canvas.mpl_connect('motion_notify_event', self.onmove)
-        self.id2 = self.canvas.mpl_connect('draw_event', self.clear)
-
     @property
     def lines(self):
         if MATPLOTLIB_VERSION < [1, 3, 0]:


### PR DESCRIPTION
.. and use stock matplotlib init method. Seems like we had some hack that is not needed anymore and our patched code breaks with matplotlib >= 3.6