### PR TITLE
properly handle event creation info being None in some cases

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ master:
    matplotlib>=3.6 (see #103)
  - adjust to an API change in matplotlib 3.6 in removing old/unwanted artists
    from axes (see #104)
+ - fix handling of events without creation info in some cases (see #106)
 
 0.8.1
  - fix reading QuakeML after Python3 port (see #98)

--- a/obspyck/obspyck.py
+++ b/obspyck/obspyck.py
@@ -3298,7 +3298,7 @@ class ObsPyck(QtWidgets.QMainWindow):
             # plot picks and arrivals
             # seiscomp does not store location code with picks, so allow to
             # match any location code in that case..
-            if str(event.get("creation_info", {}).get("author", "")).startswith("scevent"):
+            if str((event.creation_info or {}).get("author", "")).startswith("scevent"):
                 loc = None
             picks = self.getPicks(network=net, station=sta)
             try:
@@ -4180,7 +4180,7 @@ class ObsPyck(QtWidgets.QMainWindow):
         # plot picks and arrivals
         # seiscomp does not store location code with picks, so allow to
         # match any location code in that case..
-        author_ = event.get("creation_info", {}).get("author", "")
+        author_ = (event.creation_info or {}).get("author", "")
         if author_ and author_.startswith("scevent"):
             loc = None
         picks = self.getPicks(network=net, station=sta)


### PR DESCRIPTION
This could run into an error because `.get("..", {})` will still return a None value but if we chain another `.get()` after it we need a dict.